### PR TITLE
:bug: change dead link `swapi.co` to `swapi.dev` for API exercise

### DIFF
--- a/12_api/code/api.go
+++ b/12_api/code/api.go
@@ -5,7 +5,7 @@ import (
 )
 
 // BaseURL is the base endpoint for the star wars API
-const BaseURL = "https://swapi.co/api/"
+const BaseURL = "https://swapi.dev/api/"
 
 func main() {
 	fmt.Println(BaseURL)

--- a/12_api/code/api_final.go
+++ b/12_api/code/api_final.go
@@ -9,7 +9,7 @@ package main
 // )
 
 // // BaseURL is the base endpoint for the star wars API
-// const BaseURL = "https://swapi.co/api/"
+// const BaseURL = "https://swapi.dev/api/"
 
 // // Planet is a planet type
 // type Planet struct {


### PR DESCRIPTION
The original Star Wars API is no longer being hosted by the original author [ref](https://phalt.github.io/pokeapi-and-swapi-going-forward/)